### PR TITLE
fix: Update Caddy GPG key on every run

### DIFF
--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -16,9 +16,8 @@
 
 - name: Add Caddy GPG Key
   shell: |
-    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-  args:
-    creates: /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor --yes -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+  changed_when: false
 
 - name: Set GPG Key Permissions
   file:


### PR DESCRIPTION
## Description
Fixes Caddy APT repository GPG key expiry issue.

### Problem
The Caddy GPG key expired on 2025-12-28, causing apt update failures on edge nodes.

### Solution
- Remove `creates:` condition that skipped key updates
- Add `--yes` flag to gpg to overwrite existing keys
- Key is now refreshed on every playbook run