### PR TITLE
feat: enable port 9100 for monitoring and 4245 for hubble relay

### DIFF
--- a/roles/firewall/defaults/main.yml
+++ b/roles/firewall/defaults/main.yml
@@ -24,7 +24,13 @@ firewall_allowed_tcp_ports:
   - 2380   # Etcd Peer
   - 10250  # Kubelet Metrics
   - 4240   # Cilium Health
-  - 4244   # Cilium Hubble
+  - 4244   # Cilium Hubble Server
+  - 4245   # Cilium Hubble Relay
+
+# Allowed Monitoring Ports (Node Exporter)
+# Applied independently of cluster trust
+firewall_allowed_monitoring_ports:
+  - 9100   # Node Exporter
 
 # Allowed UDP Ports (Cilium, WireGuard)
 # Only applied if firewall_enable_cluster_trust is true

--- a/roles/firewall/tasks/cluster.yml
+++ b/roles/firewall/tasks/cluster.yml
@@ -44,3 +44,14 @@
     ip_version: ipv4
   when: firewall_enable_nodeports | bool
   notify: Save Firewall Rules
+
+- name: Allow Monitoring Ports (Node Exporter)
+  ansible.builtin.iptables:
+    chain: ANSIBLE-FW
+    protocol: tcp
+    destination_port: "{{ item }}"
+    jump: ACCEPT
+    action: append
+    ip_version: ipv4
+  loop: "{{ firewall_allowed_monitoring_ports }}"
+  notify: Save Firewall Rules


### PR DESCRIPTION
This PR adds port 9100 to the allowed monitoring ports and port 4245 to the allowed cluster ports. It introduces a new variable `firewall_allowed_monitoring_ports` to allow monitoring access independently of cluster trust settings.