### PR TITLE
refactor: add tags and immediate restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,5 @@ ansible all -i inventory/<name>.ini -m ping
 ansible-playbook site.yml -i inventory/<name>.ini -v
 
 ansible-playbook site.yml -i inventory/edge.ini --limit $TARGET --start-at-task="<jobs>" -v
+ansible-playbook site.yml -i inventory/edge.ini --tags "firewall,xray" --limit $TARGET -v
 ```

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -70,3 +70,6 @@
     name: caddy
     state: started
     enabled: yes
+
+- name: Force immediate handler execution
+  meta: flush_handlers

--- a/roles/node_exporter/tasks/main.yml
+++ b/roles/node_exporter/tasks/main.yml
@@ -52,3 +52,6 @@
         state: started
         enabled: true
   when: monitoring_enable_node_exporter | default(false) | bool
+
+- name: Force immediate handler execution
+  meta: flush_handlers

--- a/roles/xray/tasks/main.yml
+++ b/roles/xray/tasks/main.yml
@@ -23,3 +23,6 @@
     name: xray
     state: started
     enabled: true
+
+- name: Force immediate handler execution
+  meta: flush_handlers

--- a/site.yml
+++ b/site.yml
@@ -3,48 +3,69 @@
   become: true
   gather_facts: true
   roles:
-    - common
+    - role: common
+      tags: common
 
 - name: Configure Edge Nodes
   hosts: edge
   become: true
   gather_facts: true
   roles:
-    - tailscale
-    - firewall
-    - xray
-    - caddy
-    - derp
-    - node_exporter
+    - role: tailscale
+      tags: tailscale
+    - role: firewall
+      tags: firewall
+    - role: xray
+      tags: xray
+    - role: caddy
+      tags: caddy
+    - role: derp
+      tags: derp
+    - role: node_exporter
+      tags: node_exporter
 
 - name: Configure Control Plane
   hosts: control_plane
   become: true
   gather_facts: true
   roles:
-    - tailscale
-    - xray
-    - firewall
-    - k8s_prereqs
-    - k3s_control
-    - cilium
+    - role: tailscale
+      tags: tailscale
+    - role: xray
+      tags: xray
+    - role: firewall
+      tags: firewall
+    - role: k8s_prereqs
+      tags: k8s_prereqs
+    - role: k3s_control
+      tags: k3s_control
+    - role: cilium
+      tags: cilium
 
 - name: Configure Worker Nodes
   hosts: worker_nodes
   become: true
   gather_facts: true
   roles:
-    - tailscale
-    - xray
-    - firewall
-    - k8s_prereqs
-    - k3s_worker
+    - role: tailscale
+      tags: tailscale
+    - role: xray
+      tags: xray
+    - role: firewall
+      tags: firewall
+    - role: k8s_prereqs
+      tags: k8s_prereqs
+    - role: k3s_worker
+      tags: k3s_worker
 
 - name: Configure Sandbox Nodes (Testing Only)
   hosts: sandbox
   become: true
   gather_facts: true
   roles:
-    - tailscale
-    - xray
-    - firewall
+    - role: tailscale
+      tags: tailscale
+    - role: xray
+      tags: xray
+    - role: firewall
+      tags: firewall


### PR DESCRIPTION
Adds tags to all roles for selective execution and implements meta: flush_handlers for xray, caddy, and node_exporter to allow immediate service restarts.