### PR TITLE
Fix: Firewall Idempotency and Tailscale DNS Deadlock

### DIFF
--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -39,6 +39,9 @@
     ip_version: ipv6
   notify: Save IPv6 Firewall Rules
 
+# 7. Save rules to disk immediately
+- meta: flush_handlers
+
 - name: Enable netfilter-persistent
   service:
     name: netfilter-persistent

--- a/roles/firewall/tasks/setup.yml
+++ b/roles/firewall/tasks/setup.yml
@@ -1,5 +1,22 @@
 # IPv4 Chain Setup - SAFETY FIRST
-# 1. Allow established connections directly on INPUT (Prevents lockout when flushing custom chain)
+# Strategy: ACCEPT policy → flush INPUT → add safety rules → DROP policy
+# This guarantees a clean INPUT chain with no duplicate rules.
+
+# 1. Temporarily set INPUT policy to ACCEPT (safety net before flush)
+- name: Temporarily set INPUT policy to ACCEPT
+  ansible.builtin.iptables:
+    chain: INPUT
+    policy: ACCEPT
+    ip_version: ipv4
+
+# 2. Flush INPUT chain to remove all existing rules (including duplicates)
+- name: Flush INPUT chain
+  ansible.builtin.iptables:
+    chain: INPUT
+    flush: true
+    ip_version: ipv4
+
+# 3. Add safety rules (fresh, single copy)
 - name: Allow established connections on INPUT
   ansible.builtin.iptables:
     chain: INPUT
@@ -8,7 +25,6 @@
     action: append
     ip_version: ipv4
 
-# 2. Allow SSH directly on INPUT (Safety net)
 - name: Allow SSH on INPUT
   ansible.builtin.iptables:
     chain: INPUT
@@ -18,14 +34,6 @@
     action: append
     ip_version: ipv4
 
-# 3. Apply Default DROP Policy (Now safe because of above rules)
-- name: Set INPUT chain default policy to DROP
-  ansible.builtin.iptables:
-    chain: INPUT
-    policy: DROP
-    ip_version: ipv4
-  notify: Save Firewall Rules
-
 # 4. Manage Custom Chain
 - name: Create ANSIBLE-FW chain
   ansible.builtin.iptables:
@@ -33,20 +41,12 @@
     chain_management: true
     state: present
     ip_version: ipv4
-  notify: Save Firewall Rules
 
 - name: Flush ANSIBLE-FW chain
   ansible.builtin.iptables:
     chain: ANSIBLE-FW
     flush: true
     ip_version: ipv4
-  notify: Save Firewall Rules
-
-- name: Check if INPUT has ANSIBLE-FW jump
-  ansible.builtin.command: iptables -C INPUT -j ANSIBLE-FW
-  register: jump_check
-  failed_when: false
-  changed_when: false
 
 - name: Add INPUT jump to ANSIBLE-FW
   ansible.builtin.iptables:
@@ -54,10 +54,28 @@
     jump: ANSIBLE-FW
     action: append
     ip_version: ipv4
-  when: jump_check.rc != 0
+
+# 5. Now safe to set DROP policy (ESTABLISHED + SSH + ANSIBLE-FW jump are in place)
+- name: Set INPUT chain default policy to DROP
+  ansible.builtin.iptables:
+    chain: INPUT
+    policy: DROP
+    ip_version: ipv4
   notify: Save Firewall Rules
 
-# IPv6 Chain Setup - SAFETY FIRST
+# IPv6 Chain Setup - SAFETY FIRST (same strategy)
+- name: Temporarily set INPUT policy to ACCEPT (IPv6)
+  ansible.builtin.iptables:
+    chain: INPUT
+    policy: ACCEPT
+    ip_version: ipv6
+
+- name: Flush INPUT chain (IPv6)
+  ansible.builtin.iptables:
+    chain: INPUT
+    flush: true
+    ip_version: ipv6
+
 - name: Allow established connections on INPUT (IPv6)
   ansible.builtin.iptables:
     chain: INPUT
@@ -75,33 +93,18 @@
     action: append
     ip_version: ipv6
 
-- name: Set INPUT chain default policy to DROP (IPv6)
-  ansible.builtin.iptables:
-    chain: INPUT
-    policy: DROP
-    ip_version: ipv6
-  notify: Save IPv6 Firewall Rules
-
 - name: Create ANSIBLE-FW6 chain
   ansible.builtin.iptables:
     chain: ANSIBLE-FW6
     chain_management: true
     state: present
     ip_version: ipv6
-  notify: Save IPv6 Firewall Rules
 
 - name: Flush ANSIBLE-FW6 chain
   ansible.builtin.iptables:
     chain: ANSIBLE-FW6
     flush: true
     ip_version: ipv6
-  notify: Save IPv6 Firewall Rules
-
-- name: Check if INPUT has ANSIBLE-FW6 jump (IPv6)
-  ansible.builtin.command: ip6tables -C INPUT -j ANSIBLE-FW6
-  register: jump6_check
-  failed_when: false
-  changed_when: false
 
 - name: Add INPUT jump to ANSIBLE-FW6 (IPv6)
   ansible.builtin.iptables:
@@ -109,5 +112,10 @@
     jump: ANSIBLE-FW6
     action: append
     ip_version: ipv6
-  when: jump6_check.rc != 0
+
+- name: Set INPUT chain default policy to DROP (IPv6)
+  ansible.builtin.iptables:
+    chain: INPUT
+    policy: DROP
+    ip_version: ipv6
   notify: Save IPv6 Firewall Rules

--- a/roles/tailscale/defaults/main.yml
+++ b/roles/tailscale/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+tailscale_accept_dns: false
 tailscale_enable_peer_relay: false
 tailscale_peer_relay_port: 41641

--- a/roles/tailscale/tasks/main.yml
+++ b/roles/tailscale/tasks/main.yml
@@ -39,6 +39,10 @@
   register: tailscale_up
   changed_when: tailscale_up.rc == 0
 
+- name: Configure Tailscale DNS acceptance
+  command: tailscale set --accept-dns={{ tailscale_accept_dns | bool | lower }}
+  changed_when: false
+
 - name: Enable Tailscale Peer Relay
   command: tailscale set --relay-server-port {{ tailscale_peer_relay_port }}
   when: tailscale_enable_peer_relay | default(false)


### PR DESCRIPTION
This PR fixes two critical networking issues:

1. **Firewall Idempotency**: Rewrote setup.yml using a 'flush-and-rebuild' strategy for the INPUT chain. This prevents duplicate rules and ensures a clean state on every Ansible run.
2. **Tailscale DNS Deadlock**: Added `--accept-dns=false` to the Tailscale role. This prevents Tailscale MagicDNS from hijacking `/etc/resolv.conf`, which caused a boot-time circular dependency (deadlock) on the CP node.

Also includes cleanup of stale PVs from the decommissioned lax-wk-01 node (performed manually but noted here).